### PR TITLE
Add OAuth Testing Setup and Kanji Data Expansion

### DIFF
--- a/TESTING_OAUTH.md
+++ b/TESTING_OAUTH.md
@@ -1,0 +1,190 @@
+# 🔐 Google OAuth Testing Setup Guide
+
+## Prerequisites
+- Google Cloud Console account
+- Supabase project access
+- Local development environment
+
+## 1. Google Cloud Console Setup
+
+### Step 1: Create OAuth Credentials
+1. Visit [Google Cloud Console](https://console.cloud.google.com/)
+2. Go to "APIs & Services" > "Credentials"
+3. Click "Create Credentials" > "OAuth 2.0 Client IDs"
+4. Configure:
+   - **Application type**: Web application
+   - **Name**: Kanji Learning Local Dev
+   - **Authorized redirect URIs**:
+     ```
+     http://localhost:3000/auth/callback
+     http://localhost:3001/auth/callback
+     http://localhost:3002/auth/callback
+     http://localhost:3003/auth/callback
+     https://kvrsikfmhhppxikbnbzu.supabase.co/auth/v1/callback
+     ```
+
+### Step 2: Configure OAuth Consent Screen
+1. Go to "APIs & Services" > "OAuth consent screen"
+2. Select "External" user type
+3. Fill required fields:
+   - **App name**: Kanji Learning App
+   - **User support email**: your-email@domain.com
+   - **Developer contact**: your-email@domain.com
+4. Add scopes: `email`, `profile`
+5. Add test users (your email address)
+
+## 2. Supabase Configuration
+
+### Step 1: Enable Google Provider
+1. Go to [Supabase Dashboard](https://supabase.com/dashboard)
+2. Select your project: `kvrsikfmhhppxikbnbzu`
+3. Navigate: **Authentication** > **Providers** > **Google**
+4. Toggle **Enable Google provider**
+
+### Step 2: Add OAuth Credentials
+```
+Client ID: [From Google Cloud Console]
+Client Secret: [From Google Cloud Console]
+```
+
+### Step 3: Configure Redirect URLs
+Add these URLs in Supabase Auth settings:
+```
+http://localhost:3000/auth/callback
+http://localhost:3001/auth/callback
+http://localhost:3002/auth/callback
+http://localhost:3003/auth/callback
+```
+
+## 3. Local Testing Environment
+
+### Environment Variables
+Verify these exist in `.env.local`:
+```env
+NEXT_PUBLIC_SUPABASE_URL=https://kvrsikfmhhppxikbnbzu.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt2cnNpa2ZtaGhwcHhpa2JuYnp1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg0Mjc3MjIsImV4cCI6MjA3NDAwMzcyMn0.v5HaWAqym7q-Eb0JKjjlU4XC59yiAjANpiiUZJh32mo
+```
+
+### Testing Commands
+```bash
+# Start development server
+npm run dev
+
+# Test build (to catch issues early)
+npm run build
+
+# Check for TypeScript errors
+npm run type-check
+```
+
+## 4. Testing Procedure
+
+### Manual Testing Steps
+1. **Start dev server**: `npm run dev`
+2. **Open browser**: Navigate to `http://localhost:3000`
+3. **Click "Sign in"** button in header
+4. **Expected flow**:
+   - Redirects to Google OAuth consent screen
+   - User selects Google account
+   - User grants permissions
+   - Redirects back to `/auth/callback`
+   - Automatically redirects to home page
+   - User avatar appears in header
+   - "Sign in" button becomes "Sign Out"
+
+### Debugging Common Issues
+
+#### Issue: "Redirect URI Mismatch"
+**Solution**: Ensure all redirect URIs are added to both:
+- Google Cloud Console OAuth credentials
+- Supabase Auth provider settings
+
+#### Issue: "OAuth Consent Screen Not Configured"
+**Solution**: Complete OAuth consent screen setup in Google Cloud Console
+
+#### Issue: "Invalid Client ID"
+**Solution**: Verify Client ID matches between Google Cloud Console and Supabase
+
+#### Issue: "This app isn't verified"
+**Solution**: For testing, click "Advanced" > "Go to app (unsafe)"
+
+### Testing Different Scenarios
+
+#### Test Case 1: First-time Login
+1. Use incognito/private browsing
+2. Complete full OAuth flow
+3. Verify user data is stored in Supabase
+4. Check progress tracking works
+
+#### Test Case 2: Returning User
+1. Sign in with same account
+2. Verify existing progress is loaded
+3. Test progress synchronization
+
+#### Test Case 3: Sign Out
+1. Click "Sign Out" button
+2. Verify user is logged out
+3. Verify progress reverts to local storage
+
+## 5. Production Considerations
+
+### Before Deployment
+1. **Update redirect URIs** for production domain
+2. **Verify OAuth consent screen** for production use
+3. **Test with real users** (not just test users)
+4. **Monitor authentication metrics** in Supabase
+
+### Security Checklist
+- [ ] OAuth credentials secured
+- [ ] Redirect URIs limited to known domains
+- [ ] Supabase RLS policies configured
+- [ ] User data properly sanitized
+
+## 6. Troubleshooting Tools
+
+### Browser Developer Tools
+```javascript
+// Check auth state in browser console
+console.log(await supabase.auth.getSession())
+console.log(await supabase.auth.getUser())
+```
+
+### Supabase Auth Logs
+1. Go to Supabase Dashboard
+2. Navigate: **Authentication** > **Logs**
+3. Monitor real-time auth events
+
+### Network Tab Analysis
+1. Open browser DevTools > Network
+2. Filter for "auth" requests
+3. Check for failed requests or error responses
+
+## 7. Quick Verification Commands
+
+```bash
+# Check if environment variables are loaded
+echo $NEXT_PUBLIC_SUPABASE_URL
+
+# Test Supabase connection
+curl -X GET 'https://kvrsikfmhhppxikbnbzu.supabase.co/rest/v1/' \
+  -H "apikey: $NEXT_PUBLIC_SUPABASE_ANON_KEY"
+
+# Verify local server is running
+curl http://localhost:3000/api/health
+```
+
+## Success Indicators ✅
+
+When everything is working correctly, you should see:
+- [ ] Sign-in button is clickable and not grayed out
+- [ ] Clicking sign-in opens Google OAuth popup/redirect
+- [ ] Successful authentication shows user avatar
+- [ ] Overall progress tracking appears for signed-in users
+- [ ] Sign-out functionality works properly
+- [ ] No console errors related to authentication
+
+## Support Resources
+
+- [Supabase Auth Documentation](https://supabase.com/docs/guides/auth)
+- [Google OAuth 2.0 Documentation](https://developers.google.com/identity/protocols/oauth2)
+- [Next.js Authentication Guide](https://nextjs.org/docs/authentication)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:auth": "node scripts/test-auth-setup.js",
+    "test:health": "curl http://localhost:3000/api/health"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/scripts/test-auth-setup.js
+++ b/scripts/test-auth-setup.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+/**
+ * OAuth Setup Testing Script
+ * Run this to verify your authentication setup
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+console.log('🔐 Testing OAuth Setup...\n');
+
+// Check environment variables
+console.log('1. Checking environment variables...');
+const envPath = path.join(__dirname, '..', '.env.local');
+
+if (!fs.existsSync(envPath)) {
+  console.error('❌ .env.local file not found');
+  process.exit(1);
+}
+
+const envContent = fs.readFileSync(envPath, 'utf8');
+const hasSupabaseUrl = envContent.includes('NEXT_PUBLIC_SUPABASE_URL=');
+const hasSupabaseKey = envContent.includes('NEXT_PUBLIC_SUPABASE_ANON_KEY=');
+
+if (!hasSupabaseUrl || !hasSupabaseKey) {
+  console.error('❌ Missing Supabase environment variables');
+  process.exit(1);
+}
+
+console.log('✅ Environment variables found');
+
+// Extract Supabase URL
+const urlMatch = envContent.match(/NEXT_PUBLIC_SUPABASE_URL=(.+)/);
+const supabaseUrl = urlMatch ? urlMatch[1].trim() : null;
+
+if (!supabaseUrl || supabaseUrl.includes('placeholder')) {
+  console.error('❌ Invalid Supabase URL');
+  process.exit(1);
+}
+
+console.log(`✅ Supabase URL: ${supabaseUrl}\n`);
+
+// Test Supabase connection
+console.log('2. Testing Supabase connection...');
+
+const testUrl = `${supabaseUrl}/rest/v1/`;
+const keyMatch = envContent.match(/NEXT_PUBLIC_SUPABASE_ANON_KEY=(.+)/);
+const anonKey = keyMatch ? keyMatch[1].trim() : null;
+
+if (!anonKey) {
+  console.error('❌ Missing anonymous key');
+  process.exit(1);
+}
+
+https.get(testUrl, {
+  headers: {
+    'apikey': anonKey,
+    'Authorization': `Bearer ${anonKey}`
+  }
+}, (res) => {
+  if (res.statusCode === 200) {
+    console.log('✅ Supabase connection successful');
+  } else {
+    console.log(`⚠️  Supabase responded with status: ${res.statusCode}`);
+  }
+
+  console.log('\n3. Next steps for complete setup:');
+  console.log('   📖 Read TESTING_OAUTH.md for detailed setup instructions');
+  console.log('   🔧 Configure Google Cloud Console OAuth credentials');
+  console.log('   ⚙️  Enable Google provider in Supabase dashboard');
+  console.log('   🧪 Test sign-in flow with: npm run dev');
+  console.log('\n4. Quick test commands:');
+  console.log('   npm run dev                    # Start development server');
+  console.log('   curl http://localhost:3000/api/health  # Check server health');
+  console.log('\n🎯 OAuth setup verification complete!');
+}).on('error', (err) => {
+  console.error('❌ Supabase connection failed:', err.message);
+  process.exit(1);
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { isSupabaseConfigured } from '@/lib/supabase';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    supabaseConfigured: isSupabaseConfigured(),
+    environment: process.env.NODE_ENV,
+    port: process.env.PORT || '3000'
+  });
+}

--- a/src/app/kanji/[id]/page.tsx
+++ b/src/app/kanji/[id]/page.tsx
@@ -9,15 +9,6 @@ import Header from "@/components/Header";
 import ProgressLadder from "@/components/ProgressLadder";
 import { useProgress } from "@/hooks/useProgress";
 
-interface KanjiEntry {
-  entryId: number;
-  romaji: string;
-  hiragana: string;
-  meaning: string;
-  wordClass: string;
-  example: string;
-  exampleKana?: string;
-}
 
 interface PageProps {
   params: Promise<{ id: string }>;

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -64,11 +64,23 @@ export default function AuthButton() {
     );
   }
 
+  const handleSignIn = async () => {
+    if (!isSupabaseConfigured) {
+      alert('Authentication is not configured. Please check the Supabase configuration.');
+      return;
+    }
+    await signInWithGoogle();
+  };
+
   return (
     <button
-      onClick={signInWithGoogle}
-      className="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-gradient-to-r from-rose-500 to-pink-600 hover:from-rose-600 hover:to-pink-700 transition-all shadow-sm hover:shadow-md"
-      disabled={loading}
+      onClick={handleSignIn}
+      className={`inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium transition-all shadow-sm hover:shadow-md ${
+        isSupabaseConfigured
+          ? 'text-white bg-gradient-to-r from-rose-500 to-pink-600 hover:from-rose-600 hover:to-pink-700'
+          : 'text-gray-500 bg-gray-200 cursor-not-allowed'
+      }`}
+      disabled={loading || !isSupabaseConfigured}
     >
       <svg className="w-4 h-4 mr-2" viewBox="0 0 24 24">
         <path
@@ -88,8 +100,12 @@ export default function AuthButton() {
           d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
         />
       </svg>
-      <span className="hidden sm:inline">Sign in</span>
-      <span className="sm:hidden">Sign in</span>
+      <span className="hidden sm:inline">
+        {isSupabaseConfigured ? 'Sign in' : 'Auth not configured'}
+      </span>
+      <span className="sm:hidden">
+        {isSupabaseConfigured ? 'Sign in' : 'No auth'}
+      </span>
     </button>
   );
 }

--- a/src/data/kanji.json
+++ b/src/data/kanji.json
@@ -4561,5 +4561,455 @@
         "exampleKana": "さいしんのにゅーすをほうこくします。"
       }
     ]
+  },
+  {
+    "id": 301,
+    "kanji": "限",
+    "entries": [
+      {
+        "entryId": 308,
+        "romaji": "gen",
+        "hiragana": "げん",
+        "meaning": "limit, restrict",
+        "wordClass": "noun",
+        "example": "時間に限りがあります。(There is a time limit.)",
+        "exampleKana": "じかんにかぎりがあります。"
+      }
+    ]
+  },
+  {
+    "id": 302,
+    "kanji": "条",
+    "entries": [
+      {
+        "entryId": 309,
+        "romaji": "jou",
+        "hiragana": "じょう",
+        "meaning": "article, clause",
+        "wordClass": "noun",
+        "example": "契約の条件を確認します。(I confirm the contract conditions.)",
+        "exampleKana": "けいやくのじょうけんをかくにんします。"
+      }
+    ]
+  },
+  {
+    "id": 303,
+    "kanji": "件",
+    "entries": [
+      {
+        "entryId": 310,
+        "romaji": "ken",
+        "hiragana": "けん",
+        "meaning": "matter, case",
+        "wordClass": "noun",
+        "example": "この件について話し合いましょう。(Let's discuss this matter.)",
+        "exampleKana": "このけんについてはなしあいましょう。"
+      }
+    ]
+  },
+  {
+    "id": 304,
+    "kanji": "税",
+    "entries": [
+      {
+        "entryId": 311,
+        "romaji": "zei",
+        "hiragana": "ぜい",
+        "meaning": "tax",
+        "wordClass": "noun",
+        "example": "消費税が上がりました。(The consumption tax has increased.)",
+        "exampleKana": "しょうひぜいがあがりました。"
+      }
+    ]
+  },
+  {
+    "id": 305,
+    "kanji": "総",
+    "entries": [
+      {
+        "entryId": 312,
+        "romaji": "sou",
+        "hiragana": "そう",
+        "meaning": "total, general",
+        "wordClass": "noun",
+        "example": "総額は一万円です。(The total amount is 10,000 yen.)",
+        "exampleKana": "そうがくはいちまんえんです。"
+      }
+    ]
+  },
+  {
+    "id": 306,
+    "kanji": "放",
+    "entries": [
+      {
+        "entryId": 313,
+        "romaji": "hou",
+        "hiragana": "ほう",
+        "meaning": "release, let go",
+        "wordClass": "verb",
+        "example": "犬を公園で放しました。(I let the dog loose in the park.)",
+        "exampleKana": "いぬをこうえんではなしました。"
+      }
+    ]
+  },
+  {
+    "id": 307,
+    "kanji": "演",
+    "entries": [
+      {
+        "entryId": 314,
+        "romaji": "en",
+        "hiragana": "えん",
+        "meaning": "perform, act",
+        "wordClass": "verb",
+        "example": "劇を演じます。(I perform in a play.)",
+        "exampleKana": "げきをえんじます。"
+      }
+    ]
+  },
+  {
+    "id": 308,
+    "kanji": "習",
+    "entries": [
+      {
+        "entryId": 315,
+        "romaji": "shuu",
+        "hiragana": "しゅう",
+        "meaning": "learn, practice",
+        "wordClass": "verb",
+        "example": "毎日日本語を習います。(I study Japanese every day.)",
+        "exampleKana": "まいにちにほんごをならいます。"
+      }
+    ]
+  },
+  {
+    "id": 309,
+    "kanji": "検",
+    "entries": [
+      {
+        "entryId": 316,
+        "romaji": "ken",
+        "hiragana": "けん",
+        "meaning": "examine, inspect",
+        "wordClass": "verb",
+        "example": "車を検査します。(I inspect the car.)",
+        "exampleKana": "くるまをけんさします。"
+      }
+    ]
+  },
+  {
+    "id": 310,
+    "kanji": "討",
+    "entries": [
+      {
+        "entryId": 317,
+        "romaji": "tou",
+        "hiragana": "とう",
+        "meaning": "discuss, attack",
+        "wordClass": "verb",
+        "example": "問題を検討します。(I examine the problem.)",
+        "exampleKana": "もんだいをけんとうします。"
+      }
+    ]
+  },
+  {
+    "id": 311,
+    "kanji": "削",
+    "entries": [
+      {
+        "entryId": 318,
+        "romaji": "saku",
+        "hiragana": "さく",
+        "meaning": "cut, reduce",
+        "wordClass": "verb",
+        "example": "予算を削減します。(I reduce the budget.)",
+        "exampleKana": "よさんをさくげんします。"
+      }
+    ]
+  },
+  {
+    "id": 312,
+    "kanji": "探",
+    "entries": [
+      {
+        "entryId": 319,
+        "romaji": "tan",
+        "hiragana": "たん",
+        "meaning": "search, look for",
+        "wordClass": "verb",
+        "example": "鍵を探しています。(I am looking for my keys.)",
+        "exampleKana": "かぎをさがしています。"
+      }
+    ]
+  },
+  {
+    "id": 313,
+    "kanji": "練",
+    "entries": [
+      {
+        "entryId": 320,
+        "romaji": "ren",
+        "hiragana": "れん",
+        "meaning": "practice, train",
+        "wordClass": "verb",
+        "example": "ピアノを練習します。(I practice the piano.)",
+        "exampleKana": "ぴあのをれんしゅうします。"
+      }
+    ]
+  },
+  {
+    "id": 314,
+    "kanji": "質",
+    "entries": [
+      {
+        "entryId": 321,
+        "romaji": "shitsu",
+        "hiragana": "しつ",
+        "meaning": "quality, nature",
+        "wordClass": "noun",
+        "example": "品質が良いです。(The quality is good.)",
+        "exampleKana": "ひんしつがよいです。"
+      }
+    ]
+  },
+  {
+    "id": 315,
+    "kanji": "額",
+    "entries": [
+      {
+        "entryId": 322,
+        "romaji": "gaku",
+        "hiragana": "がく",
+        "meaning": "amount, sum",
+        "wordClass": "noun",
+        "example": "金額を計算します。(I calculate the amount.)",
+        "exampleKana": "きんがくをけいさんします。"
+      }
+    ]
+  },
+  {
+    "id": 316,
+    "kanji": "費",
+    "entries": [
+      {
+        "entryId": 323,
+        "romaji": "hi",
+        "hiragana": "ひ",
+        "meaning": "expense, cost",
+        "wordClass": "noun",
+        "example": "旅行費用を計算しました。(I calculated the travel expenses.)",
+        "exampleKana": "りょこうひようをけいさんしました。"
+      }
+    ]
+  },
+  {
+    "id": 317,
+    "kanji": "軍",
+    "entries": [
+      {
+        "entryId": 324,
+        "romaji": "gun",
+        "hiragana": "ぐん",
+        "meaning": "army, military",
+        "wordClass": "noun",
+        "example": "軍事について学びます。(I study military affairs.)",
+        "exampleKana": "ぐんじについてまなびます。"
+      }
+    ]
+  },
+  {
+    "id": 318,
+    "kanji": "票",
+    "entries": [
+      {
+        "entryId": 325,
+        "romaji": "hyou",
+        "hiragana": "ひょう",
+        "meaning": "vote, ticket",
+        "wordClass": "noun",
+        "example": "選挙で投票しました。(I voted in the election.)",
+        "exampleKana": "せんきょでとうひょうしました。"
+      }
+    ]
+  },
+  {
+    "id": 319,
+    "kanji": "精",
+    "entries": [
+      {
+        "entryId": 326,
+        "romaji": "sei",
+        "hiragana": "せい",
+        "meaning": "spirit, refined",
+        "wordClass": "noun",
+        "example": "精神力が強いです。(Mental strength is strong.)",
+        "exampleKana": "せいしんりょくがつよいです。"
+      }
+    ]
+  },
+  {
+    "id": 320,
+    "kanji": "製",
+    "entries": [
+      {
+        "entryId": 327,
+        "romaji": "sei",
+        "hiragana": "せい",
+        "meaning": "manufacture, make",
+        "wordClass": "verb",
+        "example": "日本製の車です。(It's a Japanese-made car.)",
+        "exampleKana": "にほんせいのくるまです。"
+      }
+    ]
+  },
+  {
+    "id": 321,
+    "kanji": "証",
+    "entries": [
+      {
+        "entryId": 328,
+        "romaji": "shou",
+        "hiragana": "しょう",
+        "meaning": "proof, evidence",
+        "wordClass": "noun",
+        "example": "身分証明書を見せてください。(Please show your ID.)",
+        "exampleKana": "みぶんしょうめいしょをみせてください。"
+      }
+    ]
+  },
+  {
+    "id": 322,
+    "kanji": "類",
+    "entries": [
+      {
+        "entryId": 329,
+        "romaji": "rui",
+        "hiragana": "るい",
+        "meaning": "kind, type",
+        "wordClass": "noun",
+        "example": "この種類の花が好きです。(I like this type of flower.)",
+        "exampleKana": "このしゅるいのはながすきです。"
+      }
+    ]
+  },
+  {
+    "id": 323,
+    "kanji": "装",
+    "entries": [
+      {
+        "entryId": 330,
+        "romaji": "sou",
+        "hiragana": "そう",
+        "meaning": "clothing, equipment",
+        "wordClass": "noun",
+        "example": "正装で出席します。(I will attend in formal wear.)",
+        "exampleKana": "せいそうでしゅっせきします。"
+      }
+    ]
+  },
+  {
+    "id": 324,
+    "kanji": "備",
+    "entries": [
+      {
+        "entryId": 331,
+        "romaji": "bi",
+        "hiragana": "び",
+        "meaning": "prepare, equip",
+        "wordClass": "verb",
+        "example": "旅行の準備をします。(I prepare for the trip.)",
+        "exampleKana": "りょこうのじゅんびをします。"
+      }
+    ]
+  },
+  {
+    "id": 325,
+    "kanji": "護",
+    "entries": [
+      {
+        "entryId": 332,
+        "romaji": "go",
+        "hiragana": "ご",
+        "meaning": "protect, defend",
+        "wordClass": "verb",
+        "example": "家族を護ります。(I protect my family.)",
+        "exampleKana": "かぞくをまもります。"
+      }
+    ]
+  },
+  {
+    "id": 326,
+    "kanji": "危",
+    "entries": [
+      {
+        "entryId": 333,
+        "romaji": "ki",
+        "hiragana": "き",
+        "meaning": "danger, risk",
+        "wordClass": "adjective",
+        "example": "危険な場所です。(It's a dangerous place.)",
+        "exampleKana": "きけんなばしょです。"
+      }
+    ]
+  },
+  {
+    "id": 327,
+    "kanji": "感",
+    "entries": [
+      {
+        "entryId": 334,
+        "romaji": "kan",
+        "hiragana": "かん",
+        "meaning": "feeling, sense",
+        "wordClass": "noun",
+        "example": "素晴らしい感動を受けました。(I was deeply moved.)",
+        "exampleKana": "すばらしいかんどうをうけました。"
+      }
+    ]
+  },
+  {
+    "id": 328,
+    "kanji": "録",
+    "entries": [
+      {
+        "entryId": 335,
+        "romaji": "roku",
+        "hiragana": "ろく",
+        "meaning": "record, register",
+        "wordClass": "verb",
+        "example": "テレビ番組を録画します。(I record a TV program.)",
+        "exampleKana": "てれびばんぐみをろくがします。"
+      }
+    ]
+  },
+  {
+    "id": 329,
+    "kanji": "齢",
+    "entries": [
+      {
+        "entryId": 336,
+        "romaji": "rei",
+        "hiragana": "れい",
+        "meaning": "age, years old",
+        "wordClass": "noun",
+        "example": "年齢を教えてください。(Please tell me your age.)",
+        "exampleKana": "ねんれいをおしえてください。"
+      }
+    ]
+  },
+  {
+    "id": 330,
+    "kanji": "景",
+    "entries": [
+      {
+        "entryId": 337,
+        "romaji": "kei",
+        "hiragana": "けい",
+        "meaning": "scenery, view",
+        "wordClass": "noun",
+        "example": "美しい景色を見ました。(I saw beautiful scenery.)",
+        "exampleKana": "うつくしいけしきをみました。"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- Comprehensive Google OAuth testing setup with detailed documentation and automated scripts
- Enhanced authentication error handling and user feedback
- Added 30 new kanji entries (301-330) following existing data structure
- Improved code quality by removing unused interfaces and backup files

## OAuth Testing Infrastructure
- **TESTING_OAUTH.md**: Complete setup guide for Google Cloud Console and Supabase OAuth configuration
- **scripts/test-auth-setup.js**: Automated environment verification script
- **src/app/api/health/route.ts**: Health check endpoint for testing server status
- **package.json**: Added `test:auth` and `test:health` commands for easy testing

## Authentication Improvements
- Enhanced **AuthButton.tsx** with proper configuration validation
- Added conditional styling and user feedback for authentication setup issues
- Improved error handling when Supabase is not properly configured

## Data Expansion
- Added kanji entries 301-330 to **kanji.json** with consistent formatting
- Each entry includes romaji, hiragana, meaning, word class, and example usage
- Maintains existing data structure and quality standards

## Code Quality
- Removed unused `KanjiEntry` interface from kanji detail page
- Cleaned up redundant backup files
- Fixed ESLint warnings

## Test Plan
- [x] Verify OAuth testing script runs successfully (`npm run test:auth`)
- [x] Confirm health endpoint responds correctly (`npm run test:health`)
- [x] Test authentication button behavior with/without configuration
- [x] Validate kanji data structure consistency
- [x] Check ESLint passes without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)